### PR TITLE
Update heroku stack in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,6 +11,7 @@
   "scripts": {
     "postdeploy": "pdf-bot db:migrate -c pdf-bot.config.js"
   },
+  "stack": "heroku-16",
   "repository": "https://github.com/danielwestendorf/pdf-printer",
   "env": {
     "API_TOKEN": {


### PR DESCRIPTION
When trying to deploy to Heroku, it crashes since it looks like the google chrome dependency is not compatible with heroku-18.

Specifying the stack in the `app.json` file, the heroku build is succesful.

I'm not sure if setting the stack to 16 is the best possible solution, but maybe it's a good temporary workaround.